### PR TITLE
Updated requirements.txt For Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Python package for the SendOTP API (https://sendotp.msg91.com/).
 ## Basic Usage
 
 ```python
-import sendotp
+from sendotp import sendotp
 
 otpobj =  sendotp.sendotp('Autk-Key','my message is {{otp}} keep otp with you.')
 
 # 3245 is the otp to send
-print otpobj.send(919981534313,'msgind',3245)
+print (otpobj.send(919981534313,'msgind',3245))
 
-print otpobj.verify(910000000000,3245)
+print (otpobj.verify(910000000000,3245))
 
-print otpobj.retry(910000000000) OR
-print otpobj.retry(910000000000,'text')
+print (otpobj.retry(910000000000)) OR
+print (otpobj.retry(910000000000,'text'))
 ```


### PR DESCRIPTION
Currently the Import was Showing Error (TypeError: 'module' object is not callable) when the script was trying to Create otpobj in python 3.6.
the Updated Import Fixes The Issue.
also Updated The print statements to functions.